### PR TITLE
Add Jest and mobile menu tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "abunto_website",
+  "version": "1.0.0",
+  "description": "Welcome to Abunto's professional website!",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -33,18 +33,29 @@ window.addEventListener("scroll", onScroll);
 // Mobile Menu Toggle (Responsive Nav)
 // ----------------------------
 
-// Grab the menue button (hamburger icon) and the mobile menu container
+// Grab the menu button (hamburger icon) and the mobile menu container
 const menuBtn = document.getElementById('menu-btn');
 const mobileMenu = document.getElementById('mobile-menu');
 
-// Toggle 'hidden' class on click to show/hide the mobile menu
-menuBtn.addEventListener('click', () => {
-    const isExpanded = menuBtn.getAttribute('aria-expanded') === 'true';
-    const newState = !isExpanded;
+// Expose setupMobileMenu for testing environments
+function setupMobileMenu(button, menu) {
+    if (!button || !menu) return;
+    button.addEventListener('click', () => {
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+        const newState = !isExpanded;
 
-    menuBtn.setAttribute('aria-expanded', String(newState));
-    mobileMenu.classList.toggle('hidden');
-});
+        button.setAttribute('aria-expanded', String(newState));
+        menu.classList.toggle('hidden');
+    });
+}
+
+// Toggle 'hidden' class on click to show/hide the mobile menu
+setupMobileMenu(menuBtn, mobileMenu);
+
+// Export for Node (tests)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { setupMobileMenu };
+}
 
 // ----------------------------
 // Scroll Trigger Animation (Intersection Observer)

--- a/tests/menuToggle.test.js
+++ b/tests/menuToggle.test.js
@@ -1,0 +1,31 @@
+const { JSDOM } = require('jsdom');
+const { setupMobileMenu } = require('../scripts/main');
+
+describe('Mobile menu toggle', () => {
+  let dom;
+  let menuBtn;
+  let mobileMenu;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><button id="menu-btn" aria-expanded="false"></button><div id="mobile-menu" class="hidden"></div>`);
+    const document = dom.window.document;
+    menuBtn = document.getElementById('menu-btn');
+    mobileMenu = document.getElementById('mobile-menu');
+    setupMobileMenu(menuBtn, mobileMenu);
+  });
+
+  test('click toggles hidden class and aria-expanded', () => {
+    expect(menuBtn.getAttribute('aria-expanded')).toBe('false');
+    expect(mobileMenu.classList.contains('hidden')).toBe(true);
+
+    menuBtn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+    expect(menuBtn.getAttribute('aria-expanded')).toBe('true');
+    expect(mobileMenu.classList.contains('hidden')).toBe(false);
+
+    menuBtn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+    expect(menuBtn.getAttribute('aria-expanded')).toBe('false');
+    expect(mobileMenu.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- export `setupMobileMenu` in `main.js` so tests can import it
- create `package.json` with a Jest test script and dev dependency
- ignore `node_modules`
- add Jest test verifying the menu toggling logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686321b1288c8327a67f7072e975e321